### PR TITLE
Update course crn get with new API

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -5,10 +5,9 @@ import fs from 'fs';
 import * as readline from 'readline';
 
 const COURSES_URL = 'https://uvic.kuali.co/api/v1/catalog/courses/5d9ccc4eab7506001ae4c225';
-const COURSE_DETAIL_URL = 'https://uvic.kuali.co/api/v1/catalog/course/5d9ccc4eab7506001ae4c225/'
 const SECTIONS_URL = 'https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse';
 
-const TERMS = ["201909", "202101", "202005"];
+const TERMS = ['201909', '202101', '202005'];
 
 interface Course {
   code: string;
@@ -18,28 +17,28 @@ interface Course {
   term: string;
 }
 
-interface course {
-  [key: string]: any
-  __catalogCourseId: string
-  pid: string
-  subject: string
-  code: string
+interface ParsedCourse {
+  [key: string]: string;
+  __catalogCourseId: string;
+  pid: string;
+  subject: string;
+  code: string;
 }
 
 /**
  * Gets Course subject, code, pid for all courses
  *
- * @returns {course[]} an array of all the courses
+ * @returns {ParsedCourse[]} an array of all the courses
  */
-const getCourses = async (): Promise<course[]> => {
+const getCourses = async (): Promise<ParsedCourse[]> => {
   try {
     const response = await request(COURSES_URL);
-    let courses = JSON.parse(response);
-    for (let course of courses) {
-      course.subject = course.subjectCode.name
-      course.code = course.__catalogCourseId.slice(course.subject.length)
+    const courses = JSON.parse(response);
+    for (const course of courses) {
+      course.subject = course.subjectCode.name;
+      course.code = course.__catalogCourseId.slice(course.subject.length);
     }
-    return courses
+    return courses;
   } catch (error) {
     console.log(error);
     throw new Error('Failed to get department data');
@@ -91,7 +90,7 @@ const getSections = async (params: string) => {
  */
 const getOffered = async (title: string, subject: string, code: string) => {
   try {
-    const schedules: string[] = TERMS.map((term) => `?term_in=${term}&subj_in=${subject}&crse_in=${code}&schd_in=`)
+    const schedules: string[] = TERMS.map(term => `?term_in=${term}&subj_in=${subject}&crse_in=${code}&schd_in=`);
 
     const courses: Course[] = [];
     for (const schedule of schedules) {

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -4,10 +4,12 @@ import { performance } from 'perf_hooks';
 import fs from 'fs';
 import * as readline from 'readline';
 
+import { getCurrentTerms } from './utils';
+
 const COURSES_URL = 'https://uvic.kuali.co/api/v1/catalog/courses/5d9ccc4eab7506001ae4c225';
 const SECTIONS_URL = 'https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse';
 
-const TERMS = ['201909', '202101', '202005'];
+const TERMS = getCurrentTerms(1);
 
 interface Course {
   code: string;

--- a/src/scraper_deprecated.ts
+++ b/src/scraper_deprecated.ts
@@ -4,11 +4,12 @@ import { performance } from 'perf_hooks';
 import fs from 'fs';
 import * as readline from 'readline';
 
-const COURSES_URL = 'https://uvic.kuali.co/api/v1/catalog/courses/5d9ccc4eab7506001ae4c225';
-const COURSE_DETAIL_URL = 'https://uvic.kuali.co/api/v1/catalog/course/5d9ccc4eab7506001ae4c225/'
+const BASE_URL = 'https://web.uvic.ca/calendar2020-01/CDs/';
 const SECTIONS_URL = 'https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse';
 
-const TERMS = ["201909", "202101", "202005"];
+/**
+ * This is the scraper for the old API. The API changed 2020-05
+ */
 
 interface Course {
   code: string;
@@ -18,31 +19,52 @@ interface Course {
   term: string;
 }
 
-interface course {
-  [key: string]: any
-  __catalogCourseId: string
-  pid: string
-  subject: string
-  code: string
-}
-
 /**
- * Gets Course subject, code, pid for all courses
+ * Gets the department/subject codes
  *
- * @returns {course[]} an array of all the courses
+ * @returns {string[]} an array of department codes
  */
-const getCourses = async (): Promise<course[]> => {
+const getDepartments = async () => {
   try {
-    const response = await request(COURSES_URL);
-    let courses = JSON.parse(response);
-    for (let course of courses) {
-      course.subject = course.subjectCode.name
-      course.code = course.__catalogCourseId.slice(course.subject.length)
-    }
-    return courses
+    const response = await request(BASE_URL);
+    const $ = cheerio.load(response);
+
+    const departments: string[] = [];
+    $('a').each((index, element) => {
+      const department = $(element).attr('href');
+      if (department && /^[A-Z]+/g.test(department)) {
+        departments.push(department.slice(0, -1));
+      }
+    });
+    return departments;
   } catch (error) {
     console.log(error);
     throw new Error('Failed to get department data');
+  }
+};
+
+/**
+ * Gets the course number codes
+ *
+ * @param {string} department a department code - e.g. 'CSC'
+ *
+ * @returns {string[]} an array of course codes
+ */
+const getCourseCodes = async (department: string) => {
+  try {
+    const response = await request(`${BASE_URL}${department}`);
+    const $ = cheerio.load(response);
+
+    const courses: string[] = [];
+    $('a').each((index, element) => {
+      const course = $(element).attr('href');
+      if (course && /^[0-7]+/g.test(course)) {
+        courses.push(course.slice(0, course.indexOf('.')));
+      }
+    });
+    return courses;
+  } catch (error) {
+    throw new Error('Failed to get course data');
   }
 };
 
@@ -56,8 +78,8 @@ const getCourses = async (): Promise<course[]> => {
 const getSections = async (params: string) => {
   try {
     // response = await request(url, { family: 4 });
+    console.log(`${SECTIONS_URL}${params}`)
     const response = await request(`${SECTIONS_URL}${params}`);
-
     const $ = cheerio.load(response);
 
     const crns: string[] = [];
@@ -89,9 +111,20 @@ const getSections = async (params: string) => {
  *
  * @returns {Course} - an array of all courses currently offered
  */
-const getOffered = async (title: string, subject: string, code: string) => {
+const getOffered = async (subject: string, code: string) => {
   try {
-    const schedules: string[] = TERMS.map((term) => `?term_in=${term}&subj_in=${subject}&crse_in=${code}&schd_in=`)
+    const response = await request(`${BASE_URL}${subject}/${code}.html`);
+    const $ = cheerio.load(response);
+
+    const title = $('h2').text();
+
+    const schedules: string[] = [];
+    $('#schedules')
+      .find('a')
+      .each((index, element) => {
+        const temp = $(element).attr('href');
+        if (temp) schedules.push(temp.slice(temp.indexOf('?'), temp.length));
+      });
 
     const courses: Course[] = [];
     for (const schedule of schedules) {
@@ -113,18 +146,24 @@ const main = async () => {
   const start = performance.now();
 
   const failed: string[] = [];
-  const courseCodes = await getCourses();
+  const departments = await getDepartments();
 
   process.stdout.write('Getting courses for ');
   const results: Course[] = [];
-  for (const course of courseCodes) {
+  let idx = 0
+  for (const department of departments) {
+    idx++
+    if (idx > 2) {
+      break
+    }
     try {
       readline.cursorTo(process.stdout, 20);
-      process.stdout.write(`${course.__catalogCourseId}  `);
-      const courses = await getOffered(course.title, course.subject, course.code);
+      process.stdout.write(`${department}  `);
+      const courseCodes = await getCourseCodes(department);
+      const courses = await Promise.all(courseCodes.map(async code => await getOffered(department, code)));
       results.push(...courses.flat());
     } catch (error) {
-      failed.push(course.__catalogCourseId);
+      failed.push(department);
     }
   }
   readline.clearLine(process.stdout, 0);

--- a/src/scraper_deprecated.ts
+++ b/src/scraper_deprecated.ts
@@ -78,7 +78,7 @@ const getCourseCodes = async (department: string) => {
 const getSections = async (params: string) => {
   try {
     // response = await request(url, { family: 4 });
-    console.log(`${SECTIONS_URL}${params}`)
+    console.log(`${SECTIONS_URL}${params}`);
     const response = await request(`${SECTIONS_URL}${params}`);
     const $ = cheerio.load(response);
 
@@ -150,11 +150,11 @@ const main = async () => {
 
   process.stdout.write('Getting courses for ');
   const results: Course[] = [];
-  let idx = 0
+  let idx = 0;
   for (const department of departments) {
-    idx++
+    idx++;
     if (idx > 2) {
-      break
+      break;
     }
     try {
       readline.cursorTo(process.stdout, 20);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,50 @@
+enum term {
+  '01',
+  '05',
+  '09',
+}
+
+function monthToTerm(month: number): term {
+  if (month < 1 || month > 12) {
+    throw new Error(`${month} is Not a valid month`);
+  }
+
+  if (1 <= month && month < 5) {
+    return term['01'];
+  } else if (5 <= month && month < 9) {
+    return term['05'];
+  } else {
+    return term['09'];
+  }
+}
+
+function mod(n: number, m: number): number {
+  return ((n % m) + m) % m;
+}
+
+function getTermString(currentYear: number, currentTerm: term, delta: number): string {
+  const termNumber = currentTerm.valueOf() + delta;
+
+  currentYear += Math.floor(termNumber / 3);
+  currentTerm = mod(termNumber, 3);
+
+  return currentYear.toString() + term[currentTerm].toString();
+}
+
+export function getCurrentTerms(plusMinus: number): string[] {
+  const currentTime = new Date();
+
+  const currentYear = currentTime.getFullYear();
+  const currentMonth = currentTime.getMonth() + 1;
+  const currentTerm = monthToTerm(currentMonth);
+
+  const terms: string[] = [];
+  for (let delta = 1; delta <= plusMinus; delta++) {
+    terms.push(getTermString(currentYear, currentTerm, delta));
+    terms.push(getTermString(currentYear, currentTerm, -1 * delta));
+  }
+
+  terms.push(getTermString(currentYear, currentTerm, 0));
+
+  return terms.sort();
+}


### PR DESCRIPTION
Uvic changed its course calendar!

Here's the update to keep up


Example of new scraping:
1. Visit https://uvic.kuali.co/api/v1/catalog/courses/5d9ccc4eab7506001ae4c225 and get course subject + code
2. Build query path using `?term_in=${term}&subj_in=${subject}&crse_in=${code}&schd_in=`
3. Append query path to `https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse`
ex: `https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse?term_in=202001&subj_in=CSC&crse_in=110&schd_in=`
4. Proceed with regular scraping (getting crn's, class occupancy, etc.)
