### PR TITLE
Modularize schedule and course information dumping code

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,26 @@
 
 # scheduler-scraper
 
-TODO
+## Testing
+Easy as:
+
+`npm test`
+
+This will execute tests using Jest files with the extension `*.test*`.  
+
+`npm test -- --watch` will put Jest into watch mode, which will execute tests as files change.
+
+## Developer Tools
+This repository contains a CLI to make development related tasks easier.
+
+`npm run dump -- --term 202009 --type courses` 
+- Dumps the course details for the `202009` term.
+- Outputs to a `courses.json` file.
+
+`npm run dump -- --term 202009 --type schedules` 
+- Dumps the schedule details for all `202009` term classes.
+- This schdule details corresponds to the `Class Schedule Listing` page view on BAN1P. 
+- This command can only be run after dumping courses data.
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/README.md
+++ b/README.md
@@ -17,14 +17,26 @@ This will execute tests using Jest files with the extension `*.test*`.
 ## Developer Tools
 This repository contains a CLI to make development related tasks easier.
 
-`npm run dump -- --term 202009 --type courses` 
+```
+npm run dump -- --term 202009 --type courses
+```
 - Dumps the course details for the `202009` term.
 - Outputs to a `courses.json` file.
 
-`npm run dump -- --term 202009 --type schedules` 
+```
+npm run dump -- --term 202009 --type schedules
+```
 - Dumps the schedule details for all `202009` term classes.
 - This schdule details corresponds to the `Class Schedule Listing` page view on BAN1P. 
 - This command can only be run after dumping courses data.
+
+```
+npm run dump -- --term 202009 --type class --crn 10953
+```
+- Dumps the HTML of a "Detailed Class Information" page for a given term and CRN.
+
+**Currently all file output is hardcoded to `tmp`.**
+
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1403,9 +1403,9 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "15.0.8",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.8.tgz",
-      "integrity": "sha512-b0BYzFUzBpOhPjpl1wtAHU994jBeKF4TKVlT7ssFv44T617XNcPdRoG4AzHLVshLzlrF7i3lTelH7UbuNYV58Q==",
+      "version": "15.0.9",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
+      "integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -2055,19 +2055,21 @@
       "dev": true
     },
     "cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.3.tgz",
+      "integrity": "sha512-Gj3QHTkVMPKqwP3f7B4KPkBZRMR9r4rfi5bXFpg1a+Svvj8l7q5CnkBkVQzfxT5DFSsGk2+PascOgL0JYkL2kw==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -2477,6 +2479,12 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3691,6 +3699,11 @@
             "color-convert": "^2.0.1"
           }
         },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
         "chalk": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -3698,6 +3711,16 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
           }
         },
         "color-convert": {
@@ -3712,6 +3735,15 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
         },
         "has-flag": {
           "version": "4.0.0",
@@ -3736,6 +3768,39 @@
             "jest-validate": "^26.5.3",
             "prompts": "^2.0.1",
             "yargs": "^15.4.1"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "15.4.1",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+              "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+              "requires": {
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
+              }
+            }
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
           }
         },
         "supports-color": {
@@ -3744,6 +3809,30 @@
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -5239,6 +5328,11 @@
             "color-convert": "^2.0.1"
           }
         },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
         "chalk": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -5246,6 +5340,16 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
           }
         },
         "color-convert": {
@@ -5261,10 +5365,32 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
         },
         "strip-bom": {
           "version": "4.0.0",
@@ -5277,6 +5403,48 @@
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -7620,9 +7788,9 @@
       }
     },
     "ts-node": {
-      "version": "8.10.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.0.0.tgz",
+      "integrity": "sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
@@ -7633,9 +7801,9 @@
       }
     },
     "ts-node-dev": {
-      "version": "1.0.0-pre.63",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.0.0-pre.63.tgz",
-      "integrity": "sha512-KURricXsXtiB4R+NCgiKgE01wyTe/GlXTdAPIhliDhF3kCn00kzyepAc1H8kbUJCmz0oYQq/GQ6CMtiWovs9qg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.0.0.tgz",
+      "integrity": "sha512-leA/3TgGtnVU77fGngBwVZztqyDRXirytR7dMtMWZS5b2hGpLl+VDnB0F/gf3A+HEPSzS/KwxgXFP7/LtgX4MQ==",
       "dev": true,
       "requires": {
         "chokidar": "^3.4.0",
@@ -7647,7 +7815,7 @@
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^8.10.2",
+        "ts-node": "^9.0.0",
         "tsconfig": "^7.0.0"
       },
       "dependencies": {
@@ -7934,9 +8102,10 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7947,6 +8116,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -7955,6 +8125,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -7962,12 +8133,14 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -8021,59 +8194,31 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.4.tgz",
+      "integrity": "sha512-deLOfD+RvFgrpAmSZgfGdWYE+OKyHcVHaRQ7NphG/63scpRvTHHeQMAxGGvaLVGJ+HYVcCXlzcTK0ZehFf+eHQ==",
+      "dev": true
     },
     "yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.0.tgz",
+      "integrity": "sha512-upWFJOmDdHN0syLuESuvXDmrRcWd1QafJolHskzaw79uZa7/x53gxQKiR07W59GWY1tFhhU/Th9DrtSfpS782g==",
+      "dev": true,
       "requires": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
         "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-        }
+        "y18n": "^5.0.2",
+        "yargs-parser": "^20.2.2"
       }
     },
     "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        }
-      }
+      "version": "20.2.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.3.tgz",
+      "integrity": "sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==",
+      "dev": true
     },
     "yn": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,6 +1224,12 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@types/app-root-path": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/app-root-path/-/app-root-path-1.2.4.tgz",
+      "integrity": "sha1-p4twMoKzKsVN52j1US7MNWmRncc=",
+      "dev": true
+    },
     "@types/async": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.3.tgz",
@@ -1556,6 +1562,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "app-root-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
+      "integrity": "sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw==",
+      "dev": true
     },
     "arg": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "progress": "^2.0.3"
   },
   "devDependencies": {
+    "@types/app-root-path": "^1.2.4",
     "@types/async": "^3.2.3",
     "@types/cheerio": "^0.22.22",
     "@types/jest": "^26.0.14",
@@ -27,6 +28,7 @@
     "@types/yargs": "^15.0.9",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
+    "app-root-path": "^3.0.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-node": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "UVic Web Scrapper",
   "main": "index.js",
   "scripts": {
-    "dump:kuali": "ts-node src/utils/kuali-dump.ts",
-    "dump:schedule": "ts-node src/utils/schedule-dump.ts",
+    "dump": "ts-node src/utils/cli.ts",
     "scrape": "ts-node-dev src/scraper.ts",
     "test": "jest",
     "lint": "eslint src/**/*.ts"
@@ -25,6 +24,7 @@
     "@types/cheerio": "^0.22.22",
     "@types/jest": "^26.0.14",
     "@types/progress": "^2.0.3",
+    "@types/yargs": "^15.0.9",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "eslint": "^6.8.0",
@@ -35,7 +35,8 @@
     "jest-each": "^26.5.2",
     "prettier": "^1.19.1",
     "ts-jest": "^26.4.1",
-    "ts-node-dev": "^1.0.0-pre.63",
-    "typescript": "^3.9.7"
+    "ts-node-dev": "^1.0.0",
+    "typescript": "^3.9.7",
+    "yargs": "^16.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "UVic Web Scrapper",
   "main": "index.js",
   "scripts": {
+    "dump:kuali": "ts-node src/utils/kuali-dump.ts",
+    "dump:schedule": "ts-node src/utils/schedule-dump.ts",
     "scrape": "ts-node-dev src/scraper.ts",
     "test": "jest",
     "lint": "eslint src/**/*.ts"

--- a/src/__tests__/urls.test.ts
+++ b/src/__tests__/urls.test.ts
@@ -1,0 +1,40 @@
+import {
+  classScheduleListingUrl,
+  courseListingsEntriesUrl,
+  detailedClassInformationUrl,
+  courseListingTermUrl,
+} from '../lib/urls';
+
+describe('classScheduleListingUrl', () => {
+  it('builds the URL correctly', () => {
+    const url = classScheduleListingUrl('202009', 'PAAS', '138');
+    expect(url).toBe(
+      'https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse?term_in=202009&subj_in=PAAS&crse_in=138&schd_in='
+    );
+  });
+});
+
+describe('detailedClassInformationUrl', () => {
+  it('builds the URL correctly', () => {
+    const url = detailedClassInformationUrl('202009', '12407');
+    expect(url).toBe('https://www.uvic.ca/BAN1P/bwckschd.p_disp_detail_sched?term_in=202009&crn_in=12407');
+  });
+});
+
+describe('courseListingsEntriesUrl', () => {
+  it('builds the URL correctly', () => {
+    const url = courseListingsEntriesUrl('202009', 'PAAS', '138');
+    expect(url).toBe(
+      'https://www.uvic.ca/BAN1P/bwckctlg.p_display_courses?term_in=202009&one_subj=PAAS&sel_crse_strt=138&sel_crse_end=138&sel_subj=&sel_levl=&sel_schd=&sel_coll=&sel_divs=&sel_dept=&sel_attr='
+    );
+  });
+});
+
+describe('courseListingTermUrl', () => {
+  it('builds the URL correctly', () => {
+    const url = courseListingTermUrl('202001');
+    expect(url).toBe(
+      'https://www.uvic.ca/BAN1P/bwckctlg.p_disp_cat_term_date?call_proc_in=bwckctlg.p_disp_dyn_ctlg&cat_term_in=202001'
+    );
+  });
+});

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,66 @@
+import * as qs from 'querystring';
+const BASE_URL = 'https://www.uvic.ca/BAN1P';
+
+// URL builders for known pages on UVic BAN1P.
+// Also serves as some documentation for known and useful endpoints.
+
+// GET: Class Schedule Listing
+// eg. https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse?term_in=202009&subj_in=PAAS&crse_in=138&schd_in=
+export const classScheduleListingUrl = (term: string, subject: string, course: string): string => {
+  const params = qs.stringify({
+    /* eslint-disable @typescript-eslint/camelcase */
+    term_in: term,
+    subj_in: subject,
+    crse_in: course,
+    schd_in: '',
+    /* eslint-enable @typescript-eslint/camelcase */
+  });
+  return `${BASE_URL}/bwckctlg.p_disp_listcrse?${params}`;
+};
+// GET: Detailed Class Information
+export const detailedClassInformationUrl = (term: string, crn: string): string => {
+  const params = qs.stringify({
+    /* eslint-disable @typescript-eslint/camelcase */
+    term_in: term,
+    crn_in: crn,
+    /* eslint-enable @typescript-eslint/camelcase */
+  });
+  return `${BASE_URL}/bwckschd.p_disp_detail_sched?${params}`;
+};
+
+// GET: Course Listing Entries
+// Note: can hit this endpoint with a POST request too. Difference between 
+// eg. https://www.uvic.ca/BAN1P/bwckctlg.p_display_courses?term_in=202009&one_subj=PAAS&sel_crse_strt=138&sel_crse_end=138&sel_subj=&sel_levl=&sel_schd=&sel_coll=&sel_divs=&sel_dept=&sel_attr=
+export const courseListingsEntriesUrl = (term: string, subject: string, course: string): string => {
+  // TODO: figure out what the result of the fields mean.
+  /* eslint-disable @typescript-eslint/camelcase */
+  const params = qs.stringify({
+    term_in: term,
+    one_subj: subject,
+    sel_crse_strt: course,
+    sel_crse_end: course,
+    sel_subj: '',
+    sel_levl: '',
+    sel_schd: '',
+    sel_coll: '',
+    sel_divs: '',
+    sel_dept: '',
+    sel_attr: '',
+  });
+  /* eslint-enable @typescript-eslint/camelcase */
+  return `${BASE_URL}/bwckctlg.p_display_courses?${params}`;
+};
+
+// POST: Course Listing Term
+// eg. https://www.uvic.ca/BAN1P/bwckctlg.p_disp_cat_term_date
+// qs: call_proc_in=bwckctlg.p_disp_dyn_ctlg&cat_term_in=202001
+export const courseListingTermUrl = (term: string): string => {
+  const params = qs.stringify({
+    /* eslint-disable @typescript-eslint/camelcase */
+    //   TODO: not sure what this does
+    call_proc_in: 'bwckctlg.p_disp_dyn_ctlg',
+    cat_term_in: term,
+  });
+  /* eslint-enable @typescript-eslint/camelcase */
+  return `${BASE_URL}/bwckctlg.p_disp_cat_term_date?${params}`;
+};

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -29,7 +29,7 @@ export const detailedClassInformationUrl = (term: string, crn: string): string =
 };
 
 // GET: Course Listing Entries
-// Note: can hit this endpoint with a POST request too. Difference between 
+// Note: can hit this endpoint with a POST request too. Difference between
 // eg. https://www.uvic.ca/BAN1P/bwckctlg.p_display_courses?term_in=202009&one_subj=PAAS&sel_crse_strt=138&sel_crse_end=138&sel_subj=&sel_levl=&sel_schd=&sel_coll=&sel_divs=&sel_dept=&sel_attr=
 export const courseListingsEntriesUrl = (term: string, subject: string, course: string): string => {
   // TODO: figure out what the result of the fields mean.

--- a/src/pages/courseListingEntries/__tests__/index.test.ts
+++ b/src/pages/courseListingEntries/__tests__/index.test.ts
@@ -2,9 +2,10 @@ import * as cheerio from 'cheerio';
 import fs from 'fs';
 import path from 'path';
 import { classScheduleListingExtractor } from '../index';
+import appRoot from 'app-root-path';
 
 const getFilePath = (term: string, course: string) => {
-  return path.join(__dirname, `../../../static/${course}_${term}.html`);
+  return path.join(appRoot.toString(), `src/static/${course}_${term}.html`);
 };
 
 describe('Class Schedule Listing Parser', () => {

--- a/src/pages/courseListingEntries/__tests__/index.test.ts
+++ b/src/pages/courseListingEntries/__tests__/index.test.ts
@@ -1,0 +1,27 @@
+import * as cheerio from 'cheerio';
+import fs from 'fs';
+import path from 'path';
+import { classScheduleListingExtractor } from '../index';
+
+const getFilePath = (term: string, course: string) => {
+  return path.join(__dirname, `../../../static/${course}_${term}.html`);
+};
+
+describe('Class Schedule Listing Parser', () => {
+  it('parses ECE260 correctly', async () => {
+    const $ = cheerio.load(fs.readFileSync(getFilePath('202009', 'ECE260')));
+    const parsed = await classScheduleListingExtractor($);
+
+    expect(parsed[0].title).toBe('Continuous-Time Signals and Systems');
+    expect(parsed[0].crn).toBe('10953');
+    expect(parsed[0].associatedTerm).toBe({ start: '202009', end: '202012' });
+    expect(parsed[0].registrationDates).toBe({ start: 'Jun 22, 2020', end: 'Sep 25, 2020' });
+    expect(parsed[0].campus).toBe('online');
+    expect(parsed[0].instructionalMethod).toBe('online');
+    expect(parsed[0].sectionType).toBe('lecture');
+    expect(parsed[0].credits).toBe('1.5');
+    expect(parsed[0].levels).toBe(['law', 'undergraduate']);
+    expect(parsed[0].schedule[0].type).toBe('weekly');
+    expect(parsed[0].schedule[0].instructors).toBe(['Michael David Adams']);
+  });
+});

--- a/src/pages/courseListingEntries/index.ts
+++ b/src/pages/courseListingEntries/index.ts
@@ -7,7 +7,7 @@ import { Section, Schedule } from '../../types';
  * @param {Course} course the course object to extend
  * @param {string} term the term code
  */
-export const classScheduleListingExtractor = async ($: cheerio.Root) => {
+export const classScheduleListingExtractor = async ($: cheerio.Root): Promise<Section[]> => {
   const regex = /(.+) - (\d+) - ([\w|-]{0,4} \w?\d+\w?) - ([A|B|T]\d+)/;
   try {
     const sections: Section[] = [];

--- a/src/pages/courseListingEntries/index.ts
+++ b/src/pages/courseListingEntries/index.ts
@@ -8,6 +8,7 @@ import { Section, Schedule } from '../../types';
  * @param {string} term the term code
  */
 export const classScheduleListingExtractor = async ($: cheerio.Root) => {
+  const regex = /(.+) - (\d+) - ([\w|-]{0,4} \w?\d+\w?) - ([A|B|T]\d+)/;
   try {
     const sections: Section[] = [];
     const sectionEntries = $(`table[summary="This layout table is used to present the sections found"]>tbody>tr`);
@@ -17,9 +18,11 @@ export const classScheduleListingExtractor = async ($: cheerio.Root) => {
       // Parse Title block e.g. "Algorithms and Data Structures I - 30184 - CSC 225 - A01"
       const title = $('a', sectionEntries[sectionIdx]);
       section.title = title.text();
-      const parsedTitle = title.text().split('-');
-      section.crn = parsedTitle[1].trim();
-      section.sectionCode = parsedTitle[3].trim();
+      const m = regex.exec(title.text());
+      if (m) {
+        section.crn = m[2];
+        section.sectionCode = m[4];
+      }
 
       // Get more information from section details page. Uncommenting this would increase runtime by at least x2
       // const sectionDetailsEndpoint = $('a', sectionEntries[sectionIdx]).attr('href');

--- a/src/pages/courseListingEntries/index.ts
+++ b/src/pages/courseListingEntries/index.ts
@@ -1,0 +1,80 @@
+import cheerio from 'cheerio';
+import { Section, Schedule } from '../../types';
+
+/**
+ * Extends course object with section info for term.
+ *
+ * @param {Course} course the course object to extend
+ * @param {string} term the term code
+ */
+export const classScheduleListingExtractor = async ($: cheerio.Root) => {
+  try {
+    const sections: Section[] = [];
+    const sectionEntries = $(`table[summary="This layout table is used to present the sections found"]>tbody>tr`);
+    for (let sectionIdx = 0; sectionIdx < sectionEntries.length; sectionIdx += 2) {
+      const section = {} as Section;
+
+      // Parse Title block e.g. "Algorithms and Data Structures I - 30184 - CSC 225 - A01"
+      const title = $('a', sectionEntries[sectionIdx]);
+      section.title = title.text();
+      const parsedTitle = title.text().split('-');
+      section.crn = parsedTitle[1].trim();
+      section.sectionCode = parsedTitle[3].trim();
+
+      // Get more information from section details page. Uncommenting this would increase runtime by at least x2
+      // const sectionDetailsEndpoint = $('a', sectionEntries[sectionIdx]).attr('href');
+      // if (sectionDetailsEndpoint) {
+      //   Object.assign(section, await getSectionDetails(sectionDetailsEndpoint));
+      // }
+
+      // Section info is divided into 2 table rows, here we get the second one
+      const sectionEntry = sectionEntries[sectionIdx + 1];
+
+      // Parse block before schdule table
+      const sectionInfo = $(`tr td`, sectionEntry)
+        .text()
+        .split('\n')
+        .filter(e => e.length)
+        .map(e => e.trim());
+      section.additionalInfo = sectionInfo[0];
+      section.associatedTerm = sectionInfo[1].split(/:(.+)/)[1];
+      // section.registrationDates = sectionInfo[2].split(/:(.+)/)[1];
+      section.levels = sectionInfo[3].split(/:(.+)/)[1];
+      section.location = sectionInfo[4];
+      section.sectionType = sectionInfo[5];
+      section.instructionalMethod = sectionInfo[6];
+      section.credits = sectionInfo[7];
+
+      // Parse schedule table
+      let scheduleEntries = $(
+        `table[summary="This table lists the scheduled meeting times and assigned instructors for this class.."] tbody`,
+        sectionEntry
+      )
+        .text()
+        .split('\n')
+        .filter(e => e.length);
+      const scheduleData: Schedule[] = [];
+      while (true) {
+        scheduleEntries = scheduleEntries.slice(7);
+        if (scheduleEntries.length == 0) {
+          break;
+        }
+        scheduleData.push({
+          type: scheduleEntries[0],
+          time: scheduleEntries[1],
+          days: scheduleEntries[2],
+          where: scheduleEntries[3],
+          dateRange: scheduleEntries[4],
+          scheduleType: scheduleEntries[5],
+          instructors: scheduleEntries[6],
+        });
+      }
+      section.schedule = scheduleData;
+
+      sections.push(section);
+    }
+    return sections;
+  } catch (error) {
+    throw new Error(`Failed to get sections: ${error}`);
+  }
+};

--- a/src/pages/detailedClassInformation/__tests__/index.test.ts
+++ b/src/pages/detailedClassInformation/__tests__/index.test.ts
@@ -1,0 +1,36 @@
+import * as cheerio from 'cheerio';
+import fs from 'fs';
+import path from 'path';
+import { detailedClassInfoExtractor } from '../index';
+
+const getFilePath = (term: string, crn: string) => {
+  return path.join(__dirname, `../../../static/${term}_${crn}.html`);
+};
+
+describe('Detailed Class Information', () => {
+  it('parses ECE260 correctly', async () => {
+    const $ = cheerio.load(fs.readFileSync(getFilePath('202009', '10953')));
+    const parsed = await detailedClassInfoExtractor($);
+
+    expect(parsed.seats.capacity).toBe(130);
+    expect(parsed.seats.actual).toBe(107);
+    expect(parsed.seats.remaining).toBe(23);
+
+    expect(parsed.waitlistSeats.capacity).toBe(50);
+    expect(parsed.waitlistSeats.actual).toBe(0);
+    expect(parsed.waitlistSeats.remaining).toBe(50);
+
+    // this should be broken up to optional attributes.
+    // levels is can probably be removed as it's also information we have from the class listing.
+    // the field restrictions can probably be extracted cleaner.
+    expect(parsed.requirements).toBe(`
+    Must be enrolled in one of the following Levels:     
+    Undergraduate
+Must be enrolled in one of the following Fields of Study (Major, Minor, or Concentration):
+    EN: Biomedical Engineering
+    EN: Computer Engineering
+    EN: Electrical Engr
+    EN: Software Engineering BSENG
+`);
+  });
+});

--- a/src/pages/detailedClassInformation/__tests__/index.test.ts
+++ b/src/pages/detailedClassInformation/__tests__/index.test.ts
@@ -2,9 +2,10 @@ import * as cheerio from 'cheerio';
 import fs from 'fs';
 import path from 'path';
 import { detailedClassInfoExtractor } from '../index';
+import appRoot from 'app-root-path';
 
 const getFilePath = (term: string, crn: string) => {
-  return path.join(__dirname, `../../../static/${term}_${crn}.html`);
+  return path.join(appRoot.toString(), `src/static/${term}_${crn}.html`);
 };
 
 describe('Detailed Class Information', () => {

--- a/src/pages/detailedClassInformation/index.ts
+++ b/src/pages/detailedClassInformation/index.ts
@@ -1,0 +1,38 @@
+import { Seating } from '../../types';
+
+interface SectionDetails {
+  seats: Seating;
+  waitlistSeats: Seating;
+  requirements: string[];
+}
+
+/**
+ * Gets more details of the section. Most importantly, the section capacities
+ */
+export const detailedClassInfoExtractor = async ($: cheerio.Root): Promise<SectionDetails> => {
+  const seatElement = $(`table[summary="This layout table is used to present the seating numbers."]>tbody>tr`);
+
+  const seatInfo = seatElement
+    .text()
+    .split('\n')
+    .map(e => parseInt(e, 10))
+    .filter(e => !Number.isNaN(e));
+  const requirements = $(`table[summary="This table is used to present the detailed class information."]>tbody>tr>td`)
+    .text()
+    .split('\n')
+    .filter(e => e.length);
+  const idx = requirements.findIndex(e => e === 'Restrictions:');
+  return {
+    seats: {
+      capacity: seatInfo[0],
+      actual: seatInfo[1],
+      remaining: seatInfo[2],
+    },
+    waitlistSeats: {
+      capacity: seatInfo[3],
+      actual: seatInfo[4],
+      remaining: seatInfo[5],
+    },
+    requirements: requirements.slice(idx + 1),
+  };
+};

--- a/src/static/202009_10953.html
+++ b/src/static/202009_10953.html
@@ -1,0 +1,197 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/transitional.dtd">
+<HTML lang="en">
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta http-equiv="Pragma" name="Cache-Control" content="no-cache">
+<meta http-equiv="Cache-Control" name="Cache-Control" content="no-cache">
+<LINK REL="stylesheet" HREF="/css/web_defaultapp.css" TYPE="text/css">
+<LINK REL="stylesheet" HREF="/css/web_defaultprint.css" TYPE="text/css" media="print">
+<title>Detailed Class Information</title>
+<meta http-equiv="Content-Script-Type" name="Default_Script_Language" content="text/javascript">
+<SCRIPT LANGUAGE="JavaScript" TYPE="text/javascript">
+<!-- Hide JavaScript from older browsers 
+window.onunload = function() {submitcount=0;}
+var submitcount=0;
+function checkSubmit() {
+if (submitcount == 0)
+   {
+   submitcount++;
+   return true;
+   }
+else
+   {
+alert("Your changes have already been submitted.");
+   return false;
+   }
+}
+//  End script hiding -->
+</SCRIPT>
+<SCRIPT LANGUAGE="JavaScript" TYPE="text/javascript">
+<!-- Hide JavaScript from older browsers 
+//  Function to open a window
+function windowOpen(window_url) {
+   helpWin = window.open(window_url,'','toolbar=yes,status=no,scrollbars=yes,menubar=yes,resizable=yes,directories=no,location=no,width=350,height=400');
+   if (document.images) { 
+       if (helpWin) helpWin.focus()
+   }
+}
+//  End script hiding -->
+</SCRIPT>
+<script src="/js/uvic.pack.js" language="javascript1.4" type="text/javascript" ></script>
+</head>
+<body>
+<div class="headerwrapperdiv">
+<div class="pageheaderdiv1">
+<a href="#main_content" onMouseover="window.status='Go to Main Content'; return true" onMouseout="window.status=''; return true" OnFocus="window.status='Go to Main Content'; return true" onBlur="window.status=''; return true" class="skiplinks">Go to Main Content</a>
+<h1>UVic</h1></DIV><div class="headerlinksdiv">
+</DIV>
+<table  CLASS="plaintable" SUMMARY="This table displays Menu Items and Banner Search textbox."
+         WIDTH="100%">
+<tr>
+<TD CLASS="pldefault">
+<div class="headerlinksdiv2">
+&nbsp;
+</div>
+</TD>
+<TD CLASS="pldefault"><p class="rightaligntext" /p>
+<SPAN class="pageheaderlinks">
+<a href="/wtlhelp/twbhhelp.htm" accesskey="H" onClick="popup = window.open('/wtlhelp/twbhhelp.htm', 'PopupPage','height=500,width=450,scrollbars=yes,resizable=yes'); return false" target="_blank" onMouseOver="window.status='';  return true" onMouseOut="window.status=''; return true"onFocus="window.status='';  return true" onBlur="window.status=''; return true"  class="submenulinktext2">HELP</a>
+|
+<a href="twbkwbis.P_Logout" accesskey="3" class="submenulinktext2">EXIT</a>
+</span>
+</TD>
+</tr>
+</table>
+</DIV>
+<div class="pagetitlediv">
+<table  CLASS="plaintable" SUMMARY="This table displays title and static header displays."
+   WIDTH="100%">
+<tr>
+<TD CLASS="pldefault">
+<h2>Detailed Class Information</h2>
+</TD>
+<TD CLASS="pldefault">
+&nbsp;
+</TD>
+<TD CLASS="pldefault"><p class="rightaligntext" /p>
+<div class="staticheaders">
+First Term: Sep - Dec 2020<br>
+Oct 24, 2020<br>
+</div>
+</TD>
+</tr>
+<tr>
+<TD class="bg3" width="100%" colSpan=3><img src="/wtlgifs/web_transparent.gif" alt="Transparent Image" CLASS="headerImg" TITLE="Transparent Image"  NAME="web_transparent" HSPACE=0 VSPACE=0 BORDER=0 HEIGHT=3 WIDTH=10 /></TD>
+</tr>
+</table>
+<a name="main_content"></a>
+</DIV>
+<div class="pagebodydiv">
+<!--  ** END OF twbkwbis.P_OpenDoc **  -->
+<div class="infotextdiv"><table  CLASS="infotexttable" SUMMARY="This layout table contains information that may be helpful in understanding the content and functionality of this page.  It could be a brief set of instructions, a description of error messages, or other special information."><tr><td CLASS="indefault"><SPAN class="infotext"> <script src="/js/ssb/bwckschd.p_disp_detail_sched.js" language="javascript1.4" type="text/javascript" ></script></SPAN></td></tr></table><p></DIV>
+<table  CLASS="datadisplaytable" SUMMARY="This table is used to present the detailed class information." width="100%"><caption class="captiontext">Detailed Class Information</caption>
+<tr>
+<th CLASS="ddlabel" scope="row" >Continuous-Time Signals and Systems - 10953 - ECE 260 - A01<br /><br /></th>
+</tr>
+<tr>
+<TD CLASS="dddefault">
+<SPAN class="fieldlabeltext">Associated Term: </SPAN>First Term: Sep - Dec 2020 
+<br />
+<SPAN class="fieldlabeltext">Levels: </SPAN>Law, Undergraduate 
+<br />
+<br />
+Online Campus
+<br />
+Lecture Schedule Type
+<br />
+Online Instructional Method
+<br />
+       1.500 Credits
+<br />
+<a href="/BAN1P/bwckctlg.p_display_courses?term_in=202009&amp;one_subj=ECE&amp;sel_crse_strt=260&amp;sel_crse_end=260&amp;sel_subj=&amp;sel_levl=&amp;sel_schd=&amp;sel_coll=&amp;sel_divs=&amp;sel_dept=&amp;sel_attr=">View Catalog Entry</a>
+<br />
+<br />
+<br />
+<table  CLASS="datadisplaytable" SUMMARY="This layout table is used to present the seating numbers." width = "100%"><caption class="captiontext">Registration Availability</caption>
+<tr>
+<td CLASS="dddead">&nbsp;</td>
+<th CLASS="ddheader" scope="col" ><SPAN class="fieldlabeltext">Capacity</SPAN></th>
+<th CLASS="ddheader" scope="col" ><SPAN class="fieldlabeltext">Actual</SPAN></th>
+<th CLASS="ddheader" scope="col" ><SPAN class="fieldlabeltext">Remaining</SPAN></th>
+<tr>
+<th CLASS="ddlabel" scope="row" ><SPAN class="fieldlabeltext">Seats</SPAN></th>
+<td CLASS="dddefault">130</td>
+<td CLASS="dddefault">107</td>
+<td CLASS="dddefault">23</td>
+</tr>
+<tr>
+<th CLASS="ddlabel" scope="row" ><SPAN class="fieldlabeltext">Waitlist Seats</SPAN></th>
+<td CLASS="dddefault">50</td>
+<td CLASS="dddefault">0</td>
+<td CLASS="dddefault">50</td>
+</tr>
+</table>
+<br />
+<SPAN class="fieldlabeltext">Restrictions:</SPAN>
+<br />
+Must be enrolled in one of the following Levels:&nbsp; &nbsp; &nbsp; 
+<br />
+&nbsp; &nbsp; &nbsp; Undergraduate
+<br />
+Must be enrolled in one of the following Fields of Study (Major, Minor,  or Concentration):
+<br />
+&nbsp; &nbsp; &nbsp; EN: Biomedical Engineering
+<br />
+&nbsp; &nbsp; &nbsp; EN: Computer Engineering
+<br />
+&nbsp; &nbsp; &nbsp; EN: Electrical Engr
+<br />
+&nbsp; &nbsp; &nbsp; EN: Software Engineering BSENG
+<br />
+<br />
+<div id="course-prereqs">This course contains prerequisites please see the <a target="_blank" href="https://www.uvic.ca/calendar/archives/202005/undergrad/index.php#courses/SkDdxdamN">UVic Calendar</a> for more information</div>
+<br />
+<br />
+</TD>
+</tr>
+</table>
+<br />
+<table  CLASS="datadisplaytable" SUMMARY="This is for formatting of the bottom links." WIDTH="50%">
+<tr>
+<TD CLASS="ntdefault">
+<a href="javascript:history.go(-1)" onMouseOver="window.status='Return to Previous';  return true" onFocus="window.status='Return to Previous';  return true" onMouseOut="window.status='';  return true"onBlur="window.status='';  return true">Return to Previous</a>
+</TD>
+</tr>
+</table>
+
+<!--  ** START OF twbkwbis.P_CloseDoc **  -->
+<table  CLASS="plaintable" SUMMARY="This is table displays line separator at end of the page."
+                                             WIDTH="100%" cellSpacing=0 cellPadding=0 border=0><tr><TD class="bgtabon" width="100%" colSpan=2><img src="/wtlgifs/web_transparent.gif" alt="Transparent Image" CLASS="headerImg" TITLE="Transparent Image"  NAME="web_transparent" HSPACE=0 VSPACE=0 BORDER=0 HEIGHT=3 WIDTH=10 /></TD></tr></table>
+<a href="#top" onMouseover="window.status='Skip to top of page'; return true" onMouseout="window.status=''; return true" OnFocus="window.status='Skip to top of page'; return true" onBlur="window.status=''; return true" class="skiplinks">Skip to top of page</a>
+</DIV>
+<div class="footerbeforediv">
+
+</DIV>
+<div class="footerafterdiv">
+
+</DIV>
+<div class="globalafterdiv">
+
+</DIV>
+<div class="globalfooterdiv">
+
+</DIV>
+<div class="pagefooterdiv">
+<SPAN class="releasetext">Release: 8.7.2</SPAN>
+</DIV>
+<div class="poweredbydiv">
+</DIV>
+<DIV class="div1"></DIV>
+<DIV class="div2"></DIV>
+<DIV class="div3"></DIV>
+<DIV class="div4"></DIV>
+<DIV class="div5"></DIV>
+<DIV class="div6"></DIV>
+<div class="banner_copyright"></div>
+</body>
+</html>

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,27 +14,36 @@ export interface Schedule {
   instructors: string;
 }
 
+type levelType = 'law' | 'undergraduate' | 'graduate';
+export type sectionType = 'lecture' | 'lab' | 'tutorial';
+export type deliveryMethodType = 'synchronous' | 'asynchronous' | 'mixed';
+
 export interface Section {
   term: string;
   title: string;
   crn: string;
-  sectionCode: string; //A01, B02, etc...
+  sectionCode: string;
   waitlistSeats: Seating;
   seats: Seating;
   schedule: Schedule[];
   requirements: string[];
   additionalInfo: string;
   location: string;
-  sectionType: string;
+  sectionType: sectionType;
+  deliveryMethod: deliveryMethodType;
   instructionalMethod: string;
-  campus: 'online';
-  credits: string;
-  associatedTerm: string;
+  campus: 'online' | 'in-person';
+  credits: number;
+  associatedTerm: {
+    start: string;
+    end: string;
+  };
   registrationDates: {
     start: string;
     end: string;
   };
-  levels: string;
+  levels: levelType[];
+  addtionalNotes?: string;
 }
 
 interface Term {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,20 +16,24 @@ export interface Schedule {
 
 export interface Section {
   term: string;
-  CRN: string;
+  title: string;
+  crn: string;
+  sectionCode: string; //A01, B02, etc...
   waitlistSeats: Seating;
   seats: Seating;
   schedule: Schedule[];
   requirements: string[];
-  description: string;
-  sectionCode: string; //A01, B02, etc..
   additionalInfo: string;
   location: string;
   sectionType: string;
   instructionalMethod: string;
+  campus: 'online';
   credits: string;
   associatedTerm: string;
-  registrationDates: string;
+  registrationDates: {
+    start: string;
+    end: string;
+  };
   levels: string;
 }
 

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -1,0 +1,34 @@
+import yargs from 'yargs/yargs';
+import { coursesUtil } from './kuali-dump';
+import { scheduleUtil } from './schedule-dump';
+
+const argv = yargs(process.argv.slice(2)).options({
+  term: { type: 'string', demandOption: true, description: 'term eg. 202009' },
+  type: {
+    alias: 't',
+    choices: ['courses', 'schedules', 'class'] as const,
+    demandOption: true,
+    description: 'dump target type',
+  },
+  update: { type: 'boolean', default: false, alias: 'u' },
+}).argv;
+
+const handleClass = async () => {
+  console.error('not implemented yet!');
+  return 0;
+};
+
+const main = async () => {
+  switch (argv.type) {
+    case 'courses':
+      await coursesUtil();
+      break;
+    case 'schedules':
+      await scheduleUtil(argv.term);
+      break;
+    case 'class':
+      await handleClass();
+      break;
+  }
+};
+main();

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -1,6 +1,9 @@
 import yargs from 'yargs/yargs';
 import { coursesUtil } from './kuali-dump';
 import { scheduleUtil } from './schedule-dump';
+import { detailedClassInformationUrl } from '../lib/urls';
+import got from 'got';
+import fs from 'fs';
 
 const argv = yargs(process.argv.slice(2)).options({
   term: { type: 'string', demandOption: true, description: 'term eg. 202009' },
@@ -11,11 +14,15 @@ const argv = yargs(process.argv.slice(2)).options({
     description: 'dump target type',
   },
   update: { type: 'boolean', default: false, alias: 'u' },
+  crn: {
+    alias: 'c',
+    type: 'string',
+  },
 }).argv;
 
-const handleClass = async () => {
-  console.error('not implemented yet!');
-  return 0;
+const handleClass = async (term: string, crn: string) => {
+  const response = await got(detailedClassInformationUrl(term, crn));
+  await fs.promises.writeFile(`tmp/${term}_${crn}.html`, response.rawBody);
 };
 
 const main = async () => {
@@ -27,7 +34,11 @@ const main = async () => {
       await scheduleUtil(argv.term);
       break;
     case 'class':
-      await handleClass();
+      if (!argv.crn) {
+        console.error('require CRN flag for class ');
+        return;
+      }
+      await handleClass(argv.term, argv.crn);
       break;
   }
 };

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,36 @@
+import ProgressBar from 'progress';
+import { Course } from '../types';
+import async from 'async';
+/**
+ * This is a helper function to iterate through courses and apply a given function for each course.
+ * This helper will retry failed function calls until the given function passes for all courses.
+ *
+ * @param courses courses to iterate through
+ * @param asyncfn function to apply to each course
+ * @param rateLimit limit the number of concurrently running functions
+ */
+export const forEachHelper = async (courses: Course[], asyncfn: (course: Course) => void, rateLimit: number) => {
+  let current: Course[] = courses;
+  while (current.length > 0) {
+    const bar = new ProgressBar(':bar :current/:total', { total: current.length });
+    const failedCourses: Course[] = [];
+    await async.forEachOfLimit(current, rateLimit, async (course, key, callback) => {
+      try {
+        await asyncfn(course);
+      } catch (e) {
+        bar.interrupt(`Failed ${course.catalogCourseId} ${key}: ${e}`);
+        failedCourses.push(course);
+      } finally {
+        bar.tick();
+        callback();
+        return;
+      }
+    });
+
+    if (failedCourses.length > 0) {
+      console.log(`Failed to get data on ${failedCourses.length} courses, retring`);
+    }
+    current = failedCourses;
+  }
+  return;
+};

--- a/src/utils/kuali-dump.ts
+++ b/src/utils/kuali-dump.ts
@@ -1,0 +1,68 @@
+import got from 'got';
+import { performance } from 'perf_hooks';
+import fs from 'fs';
+import { forEachHelper } from './common';
+import { Course } from '../types';
+
+const COURSES_URL = 'https://uvic.kuali.co/api/v1/catalog/courses/5d9ccc4eab7506001ae4c225';
+const COURSE_DETAIL_URL = 'https://uvic.kuali.co/api/v1/catalog/course/5d9ccc4eab7506001ae4c225/';
+
+/**
+ * Downloads Course subject, code, pid for all courses
+ *
+ * @returns {Course[]} an array of all the courses
+ */
+const downloadCourses = async (): Promise<Course[]> => {
+  try {
+    const courses: Course[] = await got(COURSES_URL).json();
+    for (const course of courses) {
+      course.subject = course.subjectCode.name;
+      course.catalogCourseId = course.__catalogCourseId;
+      course.code = course.__catalogCourseId.slice(course.subject.length);
+    }
+    return courses;
+  } catch (error) {
+    console.log(error);
+    throw new Error('Failed to get department data');
+  }
+};
+
+const main = async () => {
+  // start timer
+  const start = performance.now();
+
+  console.log('Getting all course ids');
+  // const courses = (await getCourses()).filter(e => e.subject === 'CSC');
+  const courses = await downloadCourses();
+
+  console.log('Getting course details');
+  await forEachHelper(
+    courses,
+    async (course: Course) => {
+      // ex: https://uvic.kuali.co/api/v1/catalog/course/5d9ccc4eab7506001ae4c225/r1xcyOamN
+      Object.assign(course, await got(COURSE_DETAIL_URL + course.pid).json());
+    },
+    35
+  );
+
+  // Stop timer
+  const finish = performance.now();
+
+  console.log(`Getting course data took ${(finish - start) / 60000} minutes`);
+  console.log(`${(finish - start) / courses.length} ms/course`);
+
+  fs.writeFileSync('src/static/courses.json', JSON.stringify(courses));
+  // write addtional metadata.
+  fs.writeFileSync(
+    'src/static/courses.metadata.json',
+    JSON.stringify({
+      path: COURSES_URL,
+      courseDetailPath: COURSE_DETAIL_URL,
+      // TODO this may contain links that don't work. should remove them
+      pids: courses.map((course: Course) => course.pid),
+      datetime: Date.now(),
+    })
+  );
+};
+
+main();

--- a/src/utils/kuali-dump.ts
+++ b/src/utils/kuali-dump.ts
@@ -27,7 +27,7 @@ const downloadCourses = async (): Promise<Course[]> => {
   }
 };
 
-const main = async () => {
+export const coursesUtil = async () => {
   // start timer
   const start = performance.now();
 
@@ -64,5 +64,3 @@ const main = async () => {
     })
   );
 };
-
-main();

--- a/src/utils/schedule-dump.ts
+++ b/src/utils/schedule-dump.ts
@@ -4,18 +4,18 @@ import { performance } from 'perf_hooks';
 import courses from '../static/courses.json';
 import { Course } from '../types';
 import { forEachHelper } from './common';
+import { classScheduleListingUrl } from '../lib/urls';
 
-const main = async () => {
+export const scheduleUtil = async (term: string) => {
   console.log('dump:schedule - starting...\n');
   const start = performance.now();
 
   const c: Course[] = courses;
-  const term = '202101';
 
   await forEachHelper(
     c,
     async (course: Course) => {
-      const url = `https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse?term_in=${term}&subj_in=${course.subject}&crse_in=${course.code}&schd_in=`;
+      const url = classScheduleListingUrl(term, course.subject, course.code);
       const response = await got(url);
       if (response.body.search(/No classes were found that meet your search criteria/) === -1) {
         await fs.promises.writeFile(`tmp/${course.subject}_${course.code}_${term}.html`, response.rawBody);
@@ -27,5 +27,3 @@ const main = async () => {
   const finish = performance.now();
   console.log(`Getting course data took ${(finish - start) / 60000} minutes`);
 };
-
-main();

--- a/src/utils/schedule-dump.ts
+++ b/src/utils/schedule-dump.ts
@@ -1,0 +1,31 @@
+import got from 'got';
+import * as fs from 'fs';
+import { performance } from 'perf_hooks';
+import courses from '../static/courses.json';
+import { Course } from '../types';
+import { forEachHelper } from './common';
+
+const main = async () => {
+  console.log('dump:schedule - starting...\n');
+  const start = performance.now();
+
+  const c: Course[] = courses;
+  const term = '202101';
+
+  await forEachHelper(
+    c,
+    async (course: Course) => {
+      const url = `https://www.uvic.ca/BAN1P/bwckctlg.p_disp_listcrse?term_in=${term}&subj_in=${course.subject}&crse_in=${course.code}&schd_in=`;
+      const response = await got(url);
+      if (response.body.search(/No classes were found that meet your search criteria/) === -1) {
+        await fs.promises.writeFile(`tmp/${course.subject}_${course.code}_${term}.html`, response.rawBody);
+      }
+    },
+    10
+  );
+
+  const finish = performance.now();
+  console.log(`Getting course data took ${(finish - start) / 60000} minutes`);
+};
+
+main();

--- a/src/utils/schedule-dump.ts
+++ b/src/utils/schedule-dump.ts
@@ -10,7 +10,7 @@ export const scheduleUtil = async (term: string) => {
   console.log('dump:schedule - starting...\n');
   const start = performance.now();
 
-  const c: Course[] = courses;
+  const c = courses as Course[];
 
   await forEachHelper(
     c,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,8 @@
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
+    "resolveJsonModule": true,
+
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,


### PR DESCRIPTION
Takes large the `scraper.ts` monolith and separates some of the initial dumping functionality out to individual scripts. 

They can currently be accessed as scripts.
- `dump:kuali`: downloads the list of courses and downloads the details of each course and merges them into a single file
- `dump:schedule`: downloads the courses for a given term from a list generated from the `dump:kuali` script.