### PR TITLE
Add getCourseDetails() method to API

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -4,6 +4,8 @@ import { UvicCourseScraper } from '..';
 import coursesJSON from '../../static/courses/courses.json';
 import { getSectionFileByCRN } from '../dev/path-builders';
 
+import courseDetailJSON from './static/courseDetail.json';
+
 afterEach(() => {
   nock.cleanAll();
 });
@@ -61,30 +63,7 @@ describe('call getCourseDetails()', () => {
       .reply(200, coursesJSON);
     nock('https://uvic.kuali.co')
       .get('/api/v1/catalog/course/5d9ccc4eab7506001ae4c225/SkMkeY6XV')
-      .reply(200, {
-        __passedCatalogQuery: true,
-        description:
-          '<p>Topics include basic cryptography, security protocols, access control, multilevel security, physical and environmental security, network security, application security, e-services security, human aspects and business continuity planning. Discusses applications which need various combinations of confidentiality, availability, integrity and covertness properties; mechanisms to incorporate and test these properties in systems. Policy and legal issues are also covered.</p>',
-        pid: 'SkMkeY6XV',
-        title: 'Security Engineering',
-        supplementalNotes: '',
-        __catalogCourseId: 'SENG360',
-        proForma: 'no',
-        dateStart: '2020-01-01',
-        credits: { credits: { min: '1.5', max: '1.5' }, value: '1.5', chosen: 'fixed' },
-        preAndCorequisites:
-          '<div><div><div><ul><li><span>Complete <!-- -->all<!-- --> of the following</span><ul><li data-test="ruleView-A"><div data-test="ruleView-A-result">Complete all of: <div><ul style="margin-top:5px;margin-bottom:5px"><li><span><a href="#/courses/view/5cbdf65404ce072400156009" target="_blank">SENG265</a> <!-- -->- <!-- -->Software Development Methods<!-- --> <span style="margin-left:5px">(1.5)</span></span></li></ul></div></div></li><li data-test="ruleView-B"><div data-test="ruleView-B-result"><div>minimum third-year standing in the Software Engineering or Computer Engineering or Computer Science program.</div></div></li></ul></li></ul></div></div></div>',
-        id: '5cbdf65a56bbef2400c2f0e9',
-        subjectCode: {
-          name: 'SENG',
-          description: 'Software Engineering (SENG)',
-          id: '5c14042b42504f2400e6580b',
-          linkedGroup: '5c3e3006ae5f593258bbf801',
-        },
-        catalogActivationDate: '2019-11-15',
-        hoursCatalogText: '3-2-0',
-        _score: 1,
-      });
+      .reply(200, courseDetailJSON);
 
     const client = await UvicCourseScraper();
     const courseDetails = await client.getCourseDetails('SENG', '360');

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -53,3 +53,67 @@ describe('call getSeats()', () => {
     expect(waitListSeats.remaining).toEqual(8);
   });
 });
+
+describe('call getCourseDetails()', () => {
+  it('has the expected data for a given class', async () => {
+    nock('https://uvic.kuali.co')
+      .get('/api/v1/catalog/courses/5f21b66d95f09c001ac436a0')
+      .reply(200, coursesJSON);
+    nock('https://uvic.kuali.co')
+      .get('/api/v1/catalog/course/5d9ccc4eab7506001ae4c225/SkMkeY6XV')
+      .reply(200, {
+        __passedCatalogQuery: true,
+        description:
+          '<p>Topics include basic cryptography, security protocols, access control, multilevel security, physical and environmental security, network security, application security, e-services security, human aspects and business continuity planning. Discusses applications which need various combinations of confidentiality, availability, integrity and covertness properties; mechanisms to incorporate and test these properties in systems. Policy and legal issues are also covered.</p>',
+        pid: 'SkMkeY6XV',
+        title: 'Security Engineering',
+        supplementalNotes: '',
+        __catalogCourseId: 'SENG360',
+        proForma: 'no',
+        dateStart: '2020-01-01',
+        credits: { credits: { min: '1.5', max: '1.5' }, value: '1.5', chosen: 'fixed' },
+        preAndCorequisites:
+          '<div><div><div><ul><li><span>Complete <!-- -->all<!-- --> of the following</span><ul><li data-test="ruleView-A"><div data-test="ruleView-A-result">Complete all of: <div><ul style="margin-top:5px;margin-bottom:5px"><li><span><a href="#/courses/view/5cbdf65404ce072400156009" target="_blank">SENG265</a> <!-- -->- <!-- -->Software Development Methods<!-- --> <span style="margin-left:5px">(1.5)</span></span></li></ul></div></div></li><li data-test="ruleView-B"><div data-test="ruleView-B-result"><div>minimum third-year standing in the Software Engineering or Computer Engineering or Computer Science program.</div></div></li></ul></li></ul></div></div></div>',
+        id: '5cbdf65a56bbef2400c2f0e9',
+        subjectCode: {
+          name: 'SENG',
+          description: 'Software Engineering (SENG)',
+          id: '5c14042b42504f2400e6580b',
+          linkedGroup: '5c3e3006ae5f593258bbf801',
+        },
+        catalogActivationDate: '2019-11-15',
+        hoursCatalogText: '3-2-0',
+        _score: 1,
+      });
+
+    const client = await UvicCourseScraper();
+    const courseDetails = await client.getCourseDetails('SENG', '360');
+
+    expect(courseDetails.description).toEqual(
+      'Topics include basic cryptography, security protocols, access control, multilevel security, physical and environmental security, network security, application security, e-services security, human aspects and business continuity planning. Discusses applications which need various combinations of confidentiality, availability, integrity and covertness properties; mechanisms to incorporate and test these properties in systems. Policy and legal issues are also covered.'
+    );
+    expect(courseDetails.supplementalNotes).toEqual('');
+    expect(courseDetails.proForma).toEqual('no');
+    expect(courseDetails.credits).toStrictEqual({
+      credits: { min: '1.5', max: '1.5' },
+      value: '1.5',
+      chosen: 'fixed',
+    });
+    expect(courseDetails.crossListedCourses).toBeUndefined();
+    expect(courseDetails.hoursCatalogText).toEqual('3-2-0');
+    expect(courseDetails.__catalogCourseId).toEqual('SENG360');
+    expect(courseDetails.__passedCatalogQuery).toBeTruthy();
+    expect(courseDetails.dateStart).toEqual('2020-01-01');
+    expect(courseDetails.pid).toEqual('SkMkeY6XV');
+    expect(courseDetails.id).toEqual('5cbdf65a56bbef2400c2f0e9');
+    expect(courseDetails.title).toEqual('Security Engineering');
+    expect(courseDetails.subjectCode).toStrictEqual({
+      name: 'SENG',
+      description: 'Software Engineering (SENG)',
+      id: '5c14042b42504f2400e6580b',
+      linkedGroup: '5c3e3006ae5f593258bbf801',
+    });
+    expect(courseDetails.catalogActivationDate).toEqual('2019-11-15');
+    expect(courseDetails._score).toEqual(1);
+  });
+});

--- a/src/__tests__/static/courseDetail.json
+++ b/src/__tests__/static/courseDetail.json
@@ -1,0 +1,22 @@
+{
+  "__passedCatalogQuery": true,
+  "description": "<p>Topics include basic cryptography, security protocols, access control, multilevel security, physical and environmental security, network security, application security, e-services security, human aspects and business continuity planning. Discusses applications which need various combinations of confidentiality, availability, integrity and covertness properties; mechanisms to incorporate and test these properties in systems. Policy and legal issues are also covered.</p>",
+  "pid": "SkMkeY6XV",
+  "title": "Security Engineering",
+  "supplementalNotes": "",
+  "__catalogCourseId": "SENG360",
+  "proForma": "no",
+  "dateStart": "2020-01-01",
+  "credits": { "credits": { "min": "1.5", "max": "1.5" }, "value": "1.5", "chosen": "fixed" },
+  "preAndCorequisites": "<div><div><div><ul><li><span>Complete <!-- -->all<!-- --> of the following</span><ul><li data-test=\"ruleView-A\"><div data-test=\"ruleView-A-result\">Complete all of: <div><ul style=\"margin-top:5px;margin-bottom:5px\"><li><span><a href=\"#/courses/view/5cbdf65404ce072400156009\" target=\"_blank\">SENG265</a> <!-- -->- <!-- -->Software Development Methods<!-- --> <span style=\"margin-left:5px\">(1.5)</span></span></li></ul></div></div></li><li data-test=\"ruleView-B\"><div data-test=\"ruleView-B-result\"><div>minimum third-year standing in the Software Engineering or Computer Engineering or Computer Science program.</div></div></li></ul></li></ul></div></div></div>",
+  "id": "5cbdf65a56bbef2400c2f0e9",
+  "subjectCode": {
+    "name": "SENG",
+    "description": "Software Engineering (SENG)",
+    "id": "5c14042b42504f2400e6580b",
+    "linkedGroup": "5c3e3006ae5f593258bbf801"
+  },
+  "catalogActivationDate": "2019-11-15",
+  "hoursCatalogText": "3-2-0",
+  "_score": 1
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,9 +109,7 @@ export const UvicCourseScraper = async () => {
     code: string,
     term: string = getCurrentTerm()
   ): Promise<KualiCourseItem> => {
-    const getDetails = await fetchCourseDetails(pidMap)(subject, code);
-
-    return getDetails;
+    return await fetchCourseDetails(pidMap)(subject, code);
   };
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,10 @@ const fetchSectionDetails = async (crn: string, term: string) => {
  * @param subject ie. CSC, SENG, PHYS
  * @param code ie. 100, 265, 115
  */
-const fetchCourseDetails = (pidMap: Map<string, string>) => async (subject: string, code: string) => {
+const fetchCourseDetails = (pidMap: Map<string, string>) => async (
+  subject: string,
+  code: string
+): Promise<KualiCourseItem> => {
   const pid = pidMap.get(subject + code);
   // TODO: we probably don't want to return the Kuali data as-is.
   const courseDetails = await got(COURSE_DETAIL_URL + pid).json<KualiCourseItem>();
@@ -106,10 +109,9 @@ export const UvicCourseScraper = async () => {
     code: string,
     term: string = getCurrentTerm()
   ): Promise<KualiCourseItem> => {
-    const getDetails = fetchCourseDetails(pidMap);
-    const courseDetails = (await getDetails(subject, code)) as KualiCourseItem;
+    const getDetails = await fetchCourseDetails(pidMap)(subject, code);
 
-    return courseDetails;
+    return getDetails;
   };
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,41 +107,9 @@ export const UvicCourseScraper = async () => {
     term: string = getCurrentTerm()
   ): Promise<KualiCourseItem> => {
     const getDetails = fetchCourseDetails(pidMap);
-    const {
-      description,
-      supplementalNotes,
-      proForma,
-      credits,
-      crossListedCourses,
-      hoursCatalogText,
-      __catalogCourseId,
-      __passedCatalogQuery,
-      dateStart,
-      pid,
-      id,
-      title,
-      subjectCode,
-      catalogActivationDate,
-      _score,
-    } = await getDetails(subject, code);
+    const courseDetails = (await getDetails(subject, code)) as KualiCourseItem;
 
-    return {
-      description,
-      supplementalNotes,
-      proForma,
-      credits,
-      crossListedCourses,
-      hoursCatalogText,
-      __catalogCourseId,
-      __passedCatalogQuery,
-      dateStart,
-      pid,
-      id,
-      title,
-      subjectCode,
-      catalogActivationDate,
-      _score,
-    };
+    return courseDetails;
   };
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,13 @@ export const UvicCourseScraper = async () => {
    * @param term i.e. '202009'
    * @return {Promise<KualiCourseItem>}
    */
-  const getCourseDetails = async (subject: string, code: string, term = getCurrentTerm()): Promise<KualiCourseItem> => {
+  // TODO: Implement functionality for term parameter.
+  // This will be a result of adding logic which uses the proper Kuali/BAN1P link
+  const getCourseDetails = async (
+    subject: string,
+    code: string,
+    term: string = getCurrentTerm()
+  ): Promise<KualiCourseItem> => {
     const getDetails = fetchCourseDetails(pidMap);
     const {
       description,
@@ -144,9 +150,3 @@ export const UvicCourseScraper = async () => {
     getCourseDetails,
   };
 };
-
-// const main = async () => {
-//   const client = await UvicCourseScraper();
-//   console.log(await client.getCourseDetails('SENG', '360'));
-// };
-// main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,8 @@ const fetchCourseDetails = (pidMap: Map<string, string>) => async (subject: stri
   const pid = pidMap.get(subject + code);
   // TODO: we probably don't want to return the Kuali data as-is.
   const courseDetails = await got(COURSE_DETAIL_URL + pid).json<KualiCourseItem>();
-  // TODO: strip HTML tags from courseDetails.description
+  // strip HTML tags from courseDetails.description
+  courseDetails.description = courseDetails.description.replace(/(<([^>]+)>)/gi, '');
   return courseDetails;
 };
 
@@ -90,8 +91,62 @@ export const UvicCourseScraper = async () => {
     return { seats, waitListSeats };
   };
 
+  /**
+   * Fetches course details from Kuali for a given course.
+   *
+   * @param subject i.e. 'SENG', 'ECON'
+   * @param code i.e. '360', '180A'
+   * @param term i.e. '202009'
+   * @return {Promise<KualiCourseItem>}
+   */
+  const getCourseDetails = async (subject: string, code: string, term = getCurrentTerm()): Promise<KualiCourseItem> => {
+    const getDetails = fetchCourseDetails(pidMap);
+    const {
+      description,
+      supplementalNotes,
+      proForma,
+      credits,
+      crossListedCourses,
+      hoursCatalogText,
+      __catalogCourseId,
+      __passedCatalogQuery,
+      dateStart,
+      pid,
+      id,
+      title,
+      subjectCode,
+      catalogActivationDate,
+      _score,
+    } = await getDetails(subject, code);
+
+    return {
+      description,
+      supplementalNotes,
+      proForma,
+      credits,
+      crossListedCourses,
+      hoursCatalogText,
+      __catalogCourseId,
+      __passedCatalogQuery,
+      dateStart,
+      pid,
+      id,
+      title,
+      subjectCode,
+      catalogActivationDate,
+      _score,
+    };
+  };
+
   return {
     getAllCourses,
     getSeats,
+    getCourseDetails,
   };
 };
+
+// const main = async () => {
+//   const client = await UvicCourseScraper();
+//   console.log(await client.getCourseDetails('SENG', '360'));
+// };
+// main();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ export function getCurrentTerms(plusMinus: number): string[] {
   return terms.sort();
 }
 
-export function getCurrentTerm(date: dayjs.Dayjs = dayjs()) {
+export function getCurrentTerm(date: dayjs.Dayjs = dayjs()): string {
   const year = date.year().toString();
   const currMonth = date.month();
   let month = '';


### PR DESCRIPTION
Add `getCourseDetails()` method to the client API interface. This function takes in a `subject` and a `code` for now and returns a `KualiCourseItem` object containing course specific data from Kuali. See #69 for more.

Eventually the method should take term as a parameter, however functionality will need to be implemented to determine the current Kuali & BAN1P base urls being used by UVic. These can be hard coded for now for the alpha release, but would be a nice feature in the future.

Also there might be a neater way of implementing this function... lmk

Closes #69 