### PR TITLE
Add conditional description check

### DIFF
--- a/src/kuali/catalog.ts
+++ b/src/kuali/catalog.ts
@@ -106,7 +106,7 @@ function hoursCatalog(hours: string[]) {
 
 export function KualiCourseItemParser(course: KualiCourseItem): KualiCourseItemParsed {
   // strip HTML tags from courseDetails.description
-  course.description = course.description.replace(/(<([^>]+)>)/gi, '');
+  course.description = course.description ? course.description.replace(/(<([^>]+)>)/gi, '') : '';
 
   const { hoursCatalogText, preAndCorequisites, preOrCorequisites } = course;
 


### PR DESCRIPTION
Some courses for 202309 are returning with no description, making scraper fail
Ex:
<img width="650" alt="image" src="https://github.com/VikeLabs/uvic-course-scraper/assets/50898635/5d5d2e86-6f3c-4bb9-abba-6975598f69ef">